### PR TITLE
add tokenlog config

### DIFF
--- a/tokenlog.json
+++ b/tokenlog.json
@@ -1,0 +1,8 @@
+{
+  "org": "HausDAO",
+  "repo": "DHIPs",
+  "tokenAddress": "0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb",
+  "labels": ["DHIP"],
+  "votingMethod": "QUADRATIC",
+  "chainId": 100
+}

--- a/tokenlog.json
+++ b/tokenlog.json
@@ -2,7 +2,7 @@
   "org": "HausDAO",
   "repo": "DHIPs",
   "tokenAddress": "0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb",
-  "labels": ["DHIP"],
+  "labels": ["proposal"],
   "votingMethod": "QUADRATIC",
   "chainId": 100
 }

--- a/tokenlog.json
+++ b/tokenlog.json
@@ -1,8 +1,8 @@
 {
   "org": "HausDAO",
-  "repo": "proposals",
+  "repo": "DHIPs",
   "tokenAddress": "0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb",
-  "labels": ["proposal"],
+  "labels": ["DHIP"],
   "votingMethod": "QUADRATIC",
   "chainId": 100
 }

--- a/tokenlog.json
+++ b/tokenlog.json
@@ -1,8 +1,8 @@
 {
   "org": "HausDAO",
-  "repo": "DHIPs",
+  "repo": "proposals",
   "tokenAddress": "0xb0C5f3100A4d9d9532a4CfD68c55F1AE8da987Eb",
-  "labels": ["DHIP"],
+  "labels": ["proposal"],
   "votingMethod": "QUADRATIC",
   "chainId": 100
 }


### PR DESCRIPTION
Adds the tokenlog config file to the repo. This config uses quadratic voting, but can be easily changed to 1 token 1 vote if preferred.